### PR TITLE
Improve developer experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "test:docker": "docker build -f ./Dockerfile-test -t ts-test . && docker run --rm -it ts-test",
     "tsc": "tsc"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm test"
+    }
+  },
   "files": [
     "lib",
     "!lib/**/*.spec.js",
@@ -35,6 +40,7 @@
     "@typescript-eslint/parser": "3.2.0",
     "eslint": "7.2.0",
     "eslint-plugin-import": "2.21.2",
+    "husky": "4.2.5",
     "jest": "26.0.1",
     "ts-jest": "26.1.0",
     "typescript": "3.9.5"

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,11 @@
   "schedule": [
     "on friday"
   ],
-  "automerge": true
+  "automerge": true,
+  "packageRules": [
+    {
+      "depTypeList": ["dependencies"],
+      "rangeStrategy": "bump"
+    }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es2017",
+        "target": "es2019",
         "module": "commonjs",
         "declaration": true,
         "outDir": "./lib",


### PR DESCRIPTION
* Bump target version to `es2019`
* Add `husky`, run tests in pre-commit hook
* Set Renovate to bump dependency versions. This project doesn't have dependencies, but setting this anyway for consistency with my other projects.